### PR TITLE
fix: Use `esphome/core/hal.h` to fix `millis()`

### DIFF
--- a/components/ds3231/ds3231.h
+++ b/components/ds3231/ds3231.h
@@ -3,6 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/time/real_time_clock.h"
 #include "esphome/components/i2c/i2c.h"
+#include "esphome/core/hal.h"
 
 namespace esphome {
   namespace ds3231 {


### PR DESCRIPTION
Fixes #2 

Consider moving from `millis()` to `esphome::millis()`?